### PR TITLE
Make benchmarks measure something other then startup latency

### DIFF
--- a/ahbench/__main__.py
+++ b/ahbench/__main__.py
@@ -160,6 +160,8 @@ def main():
                         if i == 0: sys.stderr.write(f"{e!r}\n")
                     finally: return  # End worker process!
         try:
+            print("Sleeping 1s to let the server start...")
+            time.sleep(1)
             subprocess.call(command)
         except Exception as e:
             print(f"Test failed: {e}")

--- a/ahbench/__main__.py
+++ b/ahbench/__main__.py
@@ -148,7 +148,7 @@ def main():
             ip, port = server_sock.getsockname()
             url = f'http://{ip}:{port}/'
             workers = 8
-            command = 'wrk', '-t8', '-c100', url
+            command = 'wrk', '--latency', '-t8', '-c100', url
             print(f"{test} >>> {' '.join(command)}")
             for i in range(workers):
                 pid = os.fork()


### PR DESCRIPTION
Bu default, `wrk` prints `Max` latency relatively prominently. This turns out to only be measuring startup time for the servers, since we start sending requests while they're still booting. Add the `--latency` flag to make it print some high percentiles to give a better picture, and also sleep 1s at startup to minimize the startup transient.

Runs on my desktop, after this change without shutdown noise removed:
```
asyncio_sockets >>> wrk --latency -t8 -c100 http://127.0.0.1:52151/
Sleeping 1s to let the server start...
Running 10s test @ http://127.0.0.1:52151/
  8 threads and 100 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   367.59us   97.38us   4.78ms   68.12%
    Req/Sec    32.70k     3.13k   63.28k    74.10%
  Latency Distribution
     50%  361.00us
     75%  432.00us
     90%  485.00us
     99%  615.00us
  2611947 requests in 10.10s, 221.69MB read
Requests/sec: 258628.05
Transfer/sec:     21.95MB

asyncio_streams >>> wrk --latency -t8 -c100 http://127.0.0.1:51981/
Sleeping 1s to let the server start...
Running 10s test @ http://127.0.0.1:51981/
  8 threads and 100 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   299.90us  112.50us   7.01ms   84.20%
    Req/Sec    40.09k     5.77k  101.23k    65.50%
  Latency Distribution
     50%  269.00us
     75%  317.00us
     90%  462.00us
     99%  594.00us
  3202389 requests in 10.10s, 271.81MB read
Requests/sec: 317083.88
Transfer/sec:     26.91MB

uvloop_sockets >>> wrk --latency -t8 -c100 http://127.0.0.1:36575/
Sleeping 1s to let the server start...
Running 10s test @ http://127.0.0.1:36575/
  8 threads and 100 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   189.38us   66.92us   4.32ms   86.95%
    Req/Sec    63.10k     5.32k  121.77k    79.35%
  Latency Distribution
     50%  181.00us
     75%  209.00us
     90%  252.00us
     99%  350.00us
  5047346 requests in 10.10s, 428.40MB read
Requests/sec: 499775.73
Transfer/sec:     42.42MB

uvloop_streams >>> wrk --latency -t8 -c100 http://127.0.0.1:38971/
Sleeping 1s to let the server start...
Running 10s test @ http://127.0.0.1:38971/
  8 threads and 100 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   178.18us   98.07us   4.99ms   80.61%
    Req/Sec    67.83k    11.58k  138.85k    64.01%
  Latency Distribution
     50%  160.00us
     75%  216.00us
     90%  286.00us
     99%  453.00us
  5418251 requests in 10.10s, 459.88MB read
Requests/sec: 536505.91
Transfer/sec:     45.54MB

trio_sockets >>> wrk --latency -t8 -c100 http://127.0.0.1:42025/
Sleeping 1s to let the server start...
Running 10s test @ http://127.0.0.1:42025/
  8 threads and 100 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   224.25us   85.80us   7.10ms   85.53%
    Req/Sec    53.49k     3.12k   84.46k    85.07%
  Latency Distribution
     50%  219.00us
     75%  257.00us
     90%  297.00us
     99%  395.00us
  4279311 requests in 10.10s, 363.22MB read
Requests/sec: 423716.31
Transfer/sec:     35.96MB

trio_streams >>> wrk --latency -t8 -c100 http://127.0.0.1:34863/
Sleeping 1s to let the server start...
Running 10s test @ http://127.0.0.1:34863/
  8 threads and 100 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   311.73us  189.16us  19.20ms   98.01%
    Req/Sec    38.82k     2.13k   67.61k    91.29%
  Latency Distribution
     50%  304.00us
     75%  349.00us
     90%  404.00us
     99%  527.00us
  3105275 requests in 10.10s, 263.57MB read
Requests/sec: 307471.08
Transfer/sec:     26.10MB
```